### PR TITLE
Add spanName requestOption so you can better name your spans when tracing

### DIFF
--- a/client/callout.go
+++ b/client/callout.go
@@ -136,7 +136,11 @@ func (c *Callout) buildRequestWithOptions(method string, url string, reqBody str
 
 func (c *Callout) doRequest(req *http.Request, writer io.Writer, opts *requestOptions) ([]byte, int, error) {
 	if opts.tracer != nil {
-		_, span := opts.tracer.Start(opts.context, req.URL.Path)
+		spanName := opts.spanName
+		if spanName == "" {
+			spanName = req.URL.Path
+		}
+		_, span := opts.tracer.Start(opts.context, spanName)
 		defer span.End()
 	}
 

--- a/client/request_options.go
+++ b/client/request_options.go
@@ -15,6 +15,7 @@ type requestOptions struct {
 	bodyWriter io.Writer
 	tracer     trace.Tracer
 	context    context.Context
+	spanName   string
 }
 
 func UnmarshalJSONBody(v interface{}) RequestOption {
@@ -53,6 +54,12 @@ func WithTracer(tracer trace.Tracer, ctx context.Context) RequestOption {
 	return func(r *requestOptions) {
 		r.tracer = tracer
 		r.context = ctx
+	}
+}
+
+func WithSpanName(spanName string) RequestOption {
+	return func(r *requestOptions) {
+		r.spanName = spanName
 	}
 }
 


### PR DESCRIPTION
Since this is a library that we all use, I figured I'd make this little change a PR just to be sure that we're happy with putting this in a shared library.

When using Lightstep for tracing, you can name your spans so it's easier to understand what's going on.
A default span name didn't make sense to me since it would apply to every span that comes from the HTTPClient (unless overwritten).
Also, I didn't test this because it seems incredibly difficult to test the otel stuff (and there weren't any tests for the tracer stuff).  I tested it via the Solana indexer though.